### PR TITLE
feat(CompressedImage): Allowed export CompressedImage topics

### DIFF
--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -24,6 +24,12 @@ topics:
     sample_interval: 5          # Write one sample every 5 messages
 
   # Configuration for the RGB image topic
+  - name: "/rgb_compressed_image_topic"    # Name of the topic to extract
+    type: "CompressedImage"               # Data type of the topic
+    encoding: "rgb8"            # Encoding format for the image
+    sample_interval: 5          # Write one sample every 5 messages
+
+  # Configuration for the RGB image topic
   - name: "/ir_image_topic"    # Name of the topic to extract
     type: "IRImage"               # Data type of the topic
     encoding: "mono16"            # Encoding format for the IR image

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -38,6 +38,7 @@ enum class MessageType
   PointCloud2,
   LaserScan,
   Image,
+  CompressedImage,
   DepthImage,
   IRImage,
   IMU,

--- a/include/rosbag2_exporter/handlers/image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/image_handler.hpp
@@ -20,11 +20,13 @@ namespace rosbag2_exporter
 
 class ImageHandler : public BaseHandler
 {
+    bool compressed_;
 public:
   // Constructor to accept logger and encoding, with a default value for encoding
   ImageHandler(const std::string & output_dir,
                const std::string & encoding,
-               rclcpp::Logger logger)
+               rclcpp::Logger logger, 
+	             bool compressed)
   : BaseHandler(logger), output_dir_(output_dir)
   {
     // Validate or set default encoding if not provided
@@ -34,6 +36,7 @@ public:
     } else {
       encoding_ = encoding;
     }
+      compressed_ = compressed;
   }
 
   // Handle uncompressed image messages
@@ -41,6 +44,9 @@ public:
                      const std::string & topic,
                      size_t index) override
   {
+      if (compressed_){
+      	return process_compressed_message(serialized_msg, topic, index);
+      }
       // Deserialize the incoming uncompressed image message
       sensor_msgs::msg::Image img;
       rclcpp::Serialization<sensor_msgs::msg::Image> serializer;

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -60,6 +60,9 @@ void BagExporter::load_configuration(const std::string & config_file)
       } else if (type == "Image") {
         tc.type = MessageType::Image;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default encoding
+      } else if (type == "CompressedImage") {
+        tc.type = MessageType::CompressedImage;
+        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default encoding
       } else if (type == "DepthImage") {
         tc.type = MessageType::DepthImage;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "16UC1"; // default encoding
@@ -102,7 +105,12 @@ void BagExporter::setup_handlers()
       auto handler = std::make_shared<PointCloudHandler>(topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::Image) {
-      auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      const bool compressed = false;
+      auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger(), compressed);
+      handlers_[topic.name] = Handler{handler, 0};
+    } else if (topic.type == MessageType::CompressedImage) {
+      const bool compressed = true;
+      auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger(), compressed);
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::DepthImage) {
       auto handler = std::make_shared<DepthImageHandler>(topic_dir, topic.encoding, this->get_logger());


### PR DESCRIPTION
Thank you very much for a very useful tool

I needed to export a CompressedImage theme and found that all the necessary functions were already written, but for some reason not being used

So I modified the code a bit so that it allows to export CompressedImages as well
My version is not very elegant, but if you find it acceptable, I hope it will make this tool better