### PR TITLE
Add compressed image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ROS2 Bag Exporter is a versatile ROS 2 (Humble Hawksbill) c++ package designed t
 #### Support for Multiple Message Types:
 - **PointCloud2**: Export point cloud data to PCD files.
 - **Image**: Convert image messages to PNG format.
+- **CompressedImage**: Convert image messages to JPG or PNG format.
 - **IR Image**: Convert IR image messages to PNG format.
 - **DepthImage**: Export depth images with appropriate encoding.
 - **LaserScan**: Export laser scan data.
@@ -89,6 +90,9 @@ topics:
   - name: "/camera/color/image_raw"
     type: "Image"
     encoding: "rgb8"
+    sample_interval: 5   # Write one sample every 5 messages
+  - name: "/camera/color/image_raw/compressed"
+    type: "CompressedImage"
     sample_interval: 5   # Write one sample every 5 messages
   - name: "/imu_topic"
     type: "IMU"

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -9,6 +9,7 @@
 #include "rosbag2_exporter/handlers/base_handler.hpp"
 #include "rosbag2_exporter/handlers/pointcloud_handler.hpp"
 #include "rosbag2_exporter/handlers/image_handler.hpp"
+#include "rosbag2_exporter/handlers/compressed_image_handler.hpp"
 #include "rosbag2_exporter/handlers/depth_image_handler.hpp"
 #include "rosbag2_exporter/handlers/ir_image_handler.hpp"
 #include "rosbag2_exporter/handlers/laser_scan_handler.hpp"
@@ -38,6 +39,7 @@ enum class MessageType
   PointCloud2,
   LaserScan,
   Image,
+  CompressedImage,
   DepthImage,
   IRImage,
   IMU,

--- a/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/compressed_image_handler.hpp
@@ -1,0 +1,101 @@
+/*
+ * This file is based on the original work by:
+ * 
+ * Original Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer
+ * Original Date: 13.10.2024
+ * 
+ * Adapted and Modified By: Hector Cruz, hector_cruz95@live.com
+ * Adaptation Date: 13.03.2025
+ * 
+ * Description of Adaptations:
+ * - Used as a template to support CompressedImages handling
+ */
+
+ #ifndef ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_
+ #define ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_
+ 
+ #include "rosbag2_exporter/handlers/base_handler.hpp"
+ #include <sensor_msgs/msg/compressed_image.hpp>
+ #include <iomanip>
+ #include <sstream>
+ #include <filesystem>
+ 
+ namespace rosbag2_exporter
+ {
+ 
+ class CompressedImageHandler : public BaseHandler
+ {
+ public:
+ 
+   CompressedImageHandler(const std::string & output_dir,
+                const std::string & encoding,
+                rclcpp::Logger logger)
+   : BaseHandler(logger), output_dir_(output_dir)
+   {}
+ 
+   // Handle compressed image messages
+   void process_message(const rclcpp::SerializedMessage & serialized_msg,
+                                   const std::string & topic,
+                                   size_t index) override
+   {
+     // Deserialize the incoming compressed image message
+     sensor_msgs::msg::CompressedImage compressed_img;
+     rclcpp::Serialization<sensor_msgs::msg::CompressedImage> serializer;
+     serializer.deserialize_message(&serialized_msg, &compressed_img);
+ 
+     // Determine file extension based on the compressed image format
+     std::string extension;
+     if (compressed_img.format.find("jpeg") != std::string::npos || compressed_img.format.find("jpg") != std::string::npos) {
+       extension = ".jpg";
+     } else if (compressed_img.format.find("png") != std::string::npos) {
+       extension = ".png";
+     } else {
+       RCLCPP_WARN(logger_, "Unknown compressed image format: %s. Defaulting to '.jpg'", compressed_img.format.c_str());
+       extension = ".jpg";  // Default to JPEG if unknown
+     }
+ 
+     // Create a timestamped filename and save compressed image directly
+     std::stringstream ss_timestamp;
+     ss_timestamp << compressed_img.header.stamp.sec << "-"
+                  << std::setw(9) << std::setfill('0') << compressed_img.header.stamp.nanosec;
+     std::string timestamp = ss_timestamp.str();
+ 
+     std::string sanitized_topic = topic;
+     // RCLCPP_WARN(logger_, "Topic-> %s", sanitized_topic.c_str());
+     if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
+       sanitized_topic = sanitized_topic.substr(1);
+     }
+ 
+     // Create the full file path
+     std::string filepath = output_dir_ + "/" + sanitized_topic + "/" + timestamp + extension;
+ 
+     // Ensure the directory exists, create if necessary
+     std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
+     if (!std::filesystem::exists(dir_path)) {
+       RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
+       std::filesystem::create_directories(dir_path);
+     }
+ 
+     // Save the compressed image data directly to file
+     std::ofstream outfile(filepath, std::ios::binary);
+     if (!outfile.is_open()) {
+       RCLCPP_ERROR(logger_, "Failed to open file to write compressed image: %s", filepath.c_str());
+       return;
+     }
+     outfile.write(reinterpret_cast<const char*>(compressed_img.data.data()), compressed_img.data.size());
+     outfile.close();
+ 
+     RCLCPP_INFO(logger_, "Successfully wrote compressed image to %s", filepath.c_str());
+   }
+ 
+ 
+ private:
+   std::string output_dir_;
+   // Defined to comply with class parent but not needed
+   std::string encoding_; 
+ 
+ };
+ 
+ }  // namespace rosbag2_exporter
+ 
+ #endif  // ROSBAG2_EXPORTER__HANDLERS__COMPRESSED_IMAGE_HANDLER_HPP_

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -60,6 +60,9 @@ void BagExporter::load_configuration(const std::string & config_file)
       } else if (type == "Image") {
         tc.type = MessageType::Image;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default encoding
+      } else if (type == "CompressedImage") {
+        tc.type = MessageType::CompressedImage;
+        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default 
       } else if (type == "DepthImage") {
         tc.type = MessageType::DepthImage;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "16UC1"; // default encoding
@@ -103,6 +106,9 @@ void BagExporter::setup_handlers()
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::Image) {
       auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger());
+      handlers_[topic.name] = Handler{handler, 0};
+    } else if (topic.type == MessageType::CompressedImage) {
+      auto handler = std::make_shared<CompressedImageHandler>(topic_dir, topic.encoding, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::DepthImage) {
       auto handler = std::make_shared<DepthImageHandler>(topic_dir, topic.encoding, this->get_logger());


### PR DESCRIPTION
Hi @Geekgineer,

Apologies for the late follow-up. As discussed in [https://github.com/Geekgineer/ros2\_bag\_exporter/pull/6](https://github.com/Geekgineer/ros2_bag_exporter/pull/6), this PR adds support for ROS 2 `sensor_msgs/CompressedImage` messages.

**Changes:**

- Add `compressed_image_handler.hpp` to define the `CompressedImage` handler class.
- Include `CompressedImage` as a supported `MessageType`.
- Update the README to reflect this new feature

