### PR TITLE
Add Flexible PointCloud2 Export Modes: Intensity, RGB, RGBA, or Auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # ROS2 Bag Exporter
 
 ![ROS2 Bag Exporter](img/cover.png)
@@ -103,6 +102,7 @@ topics:
   - name: "/lidar/points"
     type: "PointCloud2"
     sample_interval: 10   # Write one sample every 10 messages
+    save_mode: "auto"    # Optional: "intensity", "rgb", "rgba", or "auto" (default: auto)
   - name: "/path"                  
     type: "Path"                   
     sample_interval: 1    # Write one sample every single messages
@@ -118,6 +118,11 @@ topics:
   - **name**: The ROS 2 topic name.
   - **type**: The message type (PointCloud2, Image, DepthImage, IMU, GPS, etc.).
   - **sample_interval**: The interval at which messages will be written (e.g., 100 for every 100 messages).
+  - **save_mode** (PointCloud2 only, optional):
+    - `"intensity"`: Save PCD with intensity field (if present).
+    - `"rgb"`: Save PCD with RGB color (if present).
+    - `"rgba"`: Save PCD with RGBA color (if present).
+    - `"auto"` (default): Prefer intensity if present, then RGB, then RGBA, then XYZ only.
 
 ## Usage
 After building and sourcing the workspace, run the `bag_exporter` node using the following command:
@@ -153,6 +158,7 @@ topics:
   - name: "/lidar/points"
     type: "PointCloud2"
     sample_interval: 10
+    save_mode: "auto"
   - name: "/path"                  
     type: "Path"                   
     sample_interval: 1

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -16,6 +16,7 @@ topics:
   - name: "/pointcloud_topic"   # Name of the topic to extract
     type: "PointCloud2"         # Data type of the topic
     sample_interval: 10         # Write one sample every 10 messages
+    save_mode: "auto"           # Auto, prefer intensity > rgb > rgba if available
 
   # Configuration for the RGB image topic
   - name: "/rgb_image_topic"    # Name of the topic to extract

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -55,6 +55,7 @@ struct TopicConfig
   MessageType type;
   std::string encoding;
   int sample_interval;
+  std::string save_mode; // "intensity", "rgb", or "auto" (default)
 };
 
 struct Handler

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -55,7 +55,7 @@ struct TopicConfig
   MessageType type;
   std::string encoding;
   int sample_interval;
-  std::string save_mode; // "intensity", "rgb", or "auto" (default)
+  std::string save_mode;
 };
 
 struct Handler

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -14,7 +14,7 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
 {
   // Declare and get the config_file parameter (relative to package share)
   std::string config_file_param = this->declare_parameter<std::string>("config_file", "exporter_config.yaml");
-  
+
   // Find the package share directory
   std::string package_share_directory;
   try {
@@ -24,10 +24,10 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
       rclcpp::shutdown();
       return;
   }
-    
+
   // Construct the absolute path to the config file
   std::string config_file = package_share_directory + "/" + config_file_param;
-  
+
   // Load configuration
   load_configuration(config_file);
 
@@ -57,12 +57,13 @@ void BagExporter::load_configuration(const std::string & config_file)
 
       if (type == "PointCloud2") {
         tc.type = MessageType::PointCloud2;
+        tc.save_mode = topic["save_mode"] ? topic["save_mode"].as<std::string>() : "auto"; // default to auto
       } else if (type == "Image") {
         tc.type = MessageType::Image;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default encoding
       } else if (type == "CompressedImage") {
         tc.type = MessageType::CompressedImage;
-        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default 
+        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default
       } else if (type == "DepthImage") {
         tc.type = MessageType::DepthImage;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "16UC1"; // default encoding
@@ -104,7 +105,7 @@ void BagExporter::setup_handlers()
 
     // Initialize handler based on message type
     if (topic.type == MessageType::PointCloud2) {
-      auto handler = std::make_shared<PointCloudHandler>(topic_dir, this->get_logger());
+      auto handler = std::make_shared<PointCloudHandler>(topic_dir, topic.save_mode, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::Image) {
       auto handler = std::make_shared<ImageHandler>(topic_dir, topic.encoding, this->get_logger());
@@ -196,8 +197,8 @@ void BagExporter::export_bag()
           rclcpp::SerializedMessage ser_msg;
           size_t buffer_length = serialized_msg->serialized_data->buffer_length;
           ser_msg.reserve(buffer_length);
-          std::memcpy(ser_msg.get_rcl_serialized_message().buffer, 
-                      serialized_msg->serialized_data->buffer, 
+          std::memcpy(ser_msg.get_rcl_serialized_message().buffer,
+                      serialized_msg->serialized_data->buffer,
                       buffer_length);
           ser_msg.get_rcl_serialized_message().buffer_length = buffer_length;
 


### PR DESCRIPTION
This PR enhances the exporter’s flexibility for PointCloud2 topics by introducing a `save_mode` option in the configuration. Users can now explicitly choose to export point clouds with intensity (xyzi), RGB color, RGBA color, or just XYZ. The exporter can also automatically select the richest available data (in the order stated above).

This is especially useful for users that are dealing with RGB-D data that are more likely to extract RGB channels, while users working with LiDAR data can continue extracting intensity datapoints for their PCD.

New `save_mode` option:
- "intensity": Save as PCD with intensity field (if present).
- "rgb": Save as PCD with RGB color (if present).
- "rgba": Save as PCD with RGBA color (if present).
- "xyz": Save as PCD with XYZ only.
- "auto" (default): Prefer intensity, then RGB, then RGBA, then XYZ.

If save_mode is not specified, "auto" is assumed, matching previous behavior (preferred intensity > rgb > rgba > xyz). Tested on rgb rosbag extraction and works.