### PR TITLE
Added Odometry handler to export an odometry topic to csv file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ topics:
     sample_interval: 10   # Write one sample every 10 messages
   - name: "/path"                  
     type: "Path"                   
-    sample_interval: 1    # Write one sample every single messages
+    sample_interval: 1    # Write one sample every single message
+  - name: "/odom"                  
+    type: "Odometry"               
+    sample_interval: 1    # Write one sample every single message
 ```
 
 ### Parameter Descriptions
@@ -157,6 +160,9 @@ topics:
     sample_interval: 10
   - name: "/path"                  
     type: "Path"                   
+    sample_interval: 1
+  - name: "/odom"                  
+    type: "Odometry"               
     sample_interval: 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ROS2 Bag Exporter is a versatile ROS 2 (Humble Hawksbill) c++ package designed t
 - **LaserScan**: Export laser scan data.
 - **IMU**: Export IMU data for inertial measurement analysis.
 - **GPS**: Export GPS coordinates and data.
+- **Path**: Export path mesage type to CSV file (timestamp.sec,timestamp.nanosec,frame_id,pose_stamped.timestamp.sec,pose_stamped.timestamp.nanosec,pose_stamped.frame_id,pose_stamped.pose.position.x,pose_stamped.pose.position.y,pose_stamped.pose.position.z,pose_stamped.pose.orientation.x,pose_stamped.pose.orientation.y,pose_stamped.pose.orientation.z,pose_stamped.pose.orientation.w).
+- **Odometry**: Export odometry mesage type to CSV file (msg_timestamp_sec,msg_timestamp_nanosec,msg_frame_id, pos_x,pos_y,pos_z,orient_x,orient_y,orient_z,orient_w,linear_vel_x,linear_vel_y,linear_vel_z,angular_vel_x,angular_vel_y,angular_vel_z).
 
 #### Configurable Export Settings:
 - Define input bag files, output directories, and storage formats via a YAML configuration file.

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -54,3 +54,8 @@ topics:
   - name: "/path"                  # Name of the topic to extract
     type: "Path"                   # Data type of the topic
     sample_interval: 1             # Write one sample every 10 messages
+
+  # Configuration for the odometry topic
+  - name: "/odom"                  # Name of the topic to extract
+    type: "Odometry"               # Data type of the topic
+    sample_interval: 1             # Write one sample every 10 messages

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -16,6 +16,7 @@
 #include "rosbag2_exporter/handlers/imu_handler.hpp"
 #include "rosbag2_exporter/handlers/gps_handler.hpp"
 #include "rosbag2_exporter/handlers/path_handler.hpp"
+#include "rosbag2_exporter/handlers/odometry_handler.hpp"
 
 #include <yaml-cpp/yaml.h>
 #include <filesystem>
@@ -46,6 +47,7 @@ enum class MessageType
   IMU,
   GPS,
   Path,
+  Odometry,
   Unknown
 };
 
@@ -82,4 +84,4 @@ private:
 
 }  // namespace rosbag2_exporter
 
-#endif  // ROSBAG2_EXPORTER__BAG_EXPORTER_HPP_
+#endif  // ROSBAG2_EXPORTER__BAG_EXPORTER_HPP_https://github.com/barcesat/ros2_bag_exporter.git

--- a/include/rosbag2_exporter/bag_exporter.hpp
+++ b/include/rosbag2_exporter/bag_exporter.hpp
@@ -84,4 +84,4 @@ private:
 
 }  // namespace rosbag2_exporter
 
-#endif  // ROSBAG2_EXPORTER__BAG_EXPORTER_HPP_https://github.com/barcesat/ros2_bag_exporter.git
+#endif  // ROSBAG2_EXPORTER__BAG_EXPORTER_HPP

--- a/include/rosbag2_exporter/handlers/odometry_handler.hpp
+++ b/include/rosbag2_exporter/handlers/odometry_handler.hpp
@@ -1,0 +1,109 @@
+/*
+ * Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer (Template)
+ * Adapted By: [Ziv Barcesat/Barcesat], [www.linkedin.com/in/ziv-barcesat]
+ * Date: 01.05.2025
+ * Description: Handler for exporting nav_msgs/msg/Odometry messages to CSV files.
+ */
+
+#ifndef ROSBAG2_EXPORTER__HANDLERS__ODOMETRY_HANDLER_HPP_
+#define ROSBAG2_EXPORTER__HANDLERS__ODOMETRY_HANDLER_HPP_
+
+#include "rosbag2_exporter/handlers/base_handler.hpp"
+#include <nav_msgs/msg/odometry.hpp>           // Include the Odometry message type
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rclcpp/logger.hpp>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <filesystem>
+#include <vector>
+
+namespace rosbag2_exporter
+{
+
+class OdometryHandler : public BaseHandler
+{
+public:
+  // Constructor to accept output directory and logger
+  OdometryHandler(const std::string & output_dir, rclcpp::Logger logger)
+  : BaseHandler(logger), output_dir_(output_dir)
+  {}
+
+  // Override the process_message function for Odometry messages
+  void process_message(const rclcpp::SerializedMessage & serialized_msg,
+                       const std::string & topic,
+                       size_t index) override
+  {
+    // 1. Deserialize the incoming message
+    nav_msgs::msg::Odometry odom_data;
+    rclcpp::Serialization<nav_msgs::msg::Odometry> serializer;
+    serializer.deserialize_message(&serialized_msg, &odom_data);
+
+    // 2. Create a timestamp string from the message header
+    std::stringstream ss_timestamp;
+    ss_timestamp << odom_data.header.stamp.sec << "-"
+                 << std::setw(9) << std::setfill('0') << odom_data.header.stamp.nanosec;
+    std::string timestamp = ss_timestamp.str();
+
+    // 3. Sanitize the topic name (remove leading '/')
+    std::string sanitized_topic = topic;
+    if (!sanitized_topic.empty() && sanitized_topic[0] == '/') {
+      sanitized_topic = sanitized_topic.substr(1);
+    }
+
+    // 4. Construct the directory path based on the topic
+    std::filesystem::path dir_path = output_dir_ + "/" + sanitized_topic;
+
+    // 5. Ensure the directory exists, create if necessary
+    if (!std::filesystem::exists(dir_path)) {
+      RCLCPP_INFO(logger_, "Creating directory: %s", dir_path.c_str());
+      try {
+        std::filesystem::create_directories(dir_path);
+      } catch (const std::filesystem::filesystem_error& e) {
+        RCLCPP_ERROR(logger_, "Failed to create directory %s: %s", dir_path.c_str(), e.what());
+        return; // Stop processing if directory creation fails
+      }
+    }
+
+    // 6. Construct the full file path with '.csv' extension
+    std::string filepath = dir_path.string() + "/" + timestamp + ".csv";
+
+    // 7. Open the output file stream
+    std::ofstream outfile(filepath);
+    if (!outfile.is_open()) {
+      RCLCPP_ERROR(logger_, "Failed to open file to write Odometry data: %s", filepath.c_str());
+      return;
+    }
+
+    // 8. Write the CSV header
+    outfile << "msg_timestamp_sec,msg_timestamp_nanosec,msg_frame_id,"
+            << "pos_x,pos_y,pos_z,"
+            << "orient_x,orient_y,orient_z,orient_w,"
+            << "linear_vel_x,linear_vel_y,linear_vel_z,"
+            << "angular_vel_x,angular_vel_y,angular_vel_z" << std::endl;
+
+    // 9. Write the Odometry data to the CSV file
+    outfile << odom_data.header.stamp.sec << "," << odom_data.header.stamp.nanosec << ","
+            << odom_data.header.frame_id << ","
+            << odom_data.pose.pose.position.x << "," << odom_data.pose.pose.position.y << "," << odom_data.pose.pose.position.z << ","
+            << odom_data.pose.pose.orientation.x << "," << odom_data.pose.pose.orientation.y << "," << odom_data.pose.pose.orientation.z << "," << odom_data.pose.pose.orientation.w << ","
+            << odom_data.twist.twist.linear.x << "," << odom_data.twist.twist.linear.y << "," << odom_data.twist.twist.linear.z << ","
+            << odom_data.twist.twist.angular.x << "," << odom_data.twist.twist.angular.y << "," << odom_data.twist.twist.angular.z
+            << std::endl;
+
+    // 10. Close the file
+    outfile.close();
+
+    // 11. Log success
+    RCLCPP_INFO(logger_, "Successfully wrote Odometry data (message #%zu) to %s", index, filepath.c_str());
+  }
+
+private:
+  std::string output_dir_; // Directory where files will be saved
+};
+
+}  // namespace rosbag2_exporter
+
+#endif  // ROSBAG2_EXPORTER__HANDLERS__ODOMETRY_HANDLER_HPP_

--- a/src/bag_exporter.cpp
+++ b/src/bag_exporter.cpp
@@ -14,7 +14,7 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
 {
   // Declare and get the config_file parameter (relative to package share)
   std::string config_file_param = this->declare_parameter<std::string>("config_file", "exporter_config.yaml");
-  
+
   // Find the package share directory
   std::string package_share_directory;
   try {
@@ -24,10 +24,10 @@ BagExporter::BagExporter(const rclcpp::NodeOptions & options)
       rclcpp::shutdown();
       return;
   }
-    
+
   // Construct the absolute path to the config file
   std::string config_file = package_share_directory + "/" + config_file_param;
-  
+
   // Load configuration
   load_configuration(config_file);
 
@@ -62,7 +62,7 @@ void BagExporter::load_configuration(const std::string & config_file)
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default encoding
       } else if (type == "CompressedImage") {
         tc.type = MessageType::CompressedImage;
-        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default 
+        tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "rgb8"; // default
       } else if (type == "DepthImage") {
         tc.type = MessageType::DepthImage;
         tc.encoding = topic["encoding"] ? topic["encoding"].as<std::string>() : "16UC1"; // default encoding
@@ -74,6 +74,8 @@ void BagExporter::load_configuration(const std::string & config_file)
         tc.type = MessageType::LaserScan;
       } else if (type == "Path") {
         tc.type = MessageType::Path;
+      } else if (type == "Odometry") {
+        tc.type = MessageType::Odometry;
       } else {
         tc.type = MessageType::Unknown;
       }
@@ -129,6 +131,9 @@ void BagExporter::setup_handlers()
       handlers_[topic.name] = Handler{handler, 0};
     } else if (topic.type == MessageType::Path) {
       auto handler = std::make_shared<PathHandler>(topic_dir, this->get_logger());
+      handlers_[topic.name] = Handler{handler, 0};
+    } else if (topic.type == MessageType::Odometry) {
+      auto handler = std::make_shared<OdometryHandler>(topic_dir, this->get_logger());
       handlers_[topic.name] = Handler{handler, 0};
     } else {
       RCLCPP_WARN(this->get_logger(), "Unsupported message type for topic '%s'. Skipping.", topic.name.c_str());
@@ -196,8 +201,8 @@ void BagExporter::export_bag()
           rclcpp::SerializedMessage ser_msg;
           size_t buffer_length = serialized_msg->serialized_data->buffer_length;
           ser_msg.reserve(buffer_length);
-          std::memcpy(ser_msg.get_rcl_serialized_message().buffer, 
-                      serialized_msg->serialized_data->buffer, 
+          std::memcpy(ser_msg.get_rcl_serialized_message().buffer,
+                      serialized_msg->serialized_data->buffer,
                       buffer_length);
           ser_msg.get_rcl_serialized_message().buffer_length = buffer_length;
 


### PR DESCRIPTION
Hello @Geekgineer,
Following the path topic type addition, A friend of mine has added a feature to the code to be able to handle and export odometry topics to CSV files.
I've added the examples in the YAML and README files and we're happy to contribute back again.
Thanks,
Ziv & Garry