### PR TITLE
Options for depth image export

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ROS2 Bag Exporter is a versatile ROS 2 (Humble Hawksbill) c++ package designed t
 #### Automatic Directory Management:
 - Automatically creates necessary directories for each topic based on the configuration.
 
-## Install 
+## Install
 ### Dependencies
 Ensure that the following dependencies are installed on your system:
 - ROS 2 Humble Hawksbill
@@ -47,7 +47,7 @@ Ensure that the following dependencies are installed on your system:
 You can install the necessary dependencies using apt:
 ```bash
 sudo apt update
-sudo apt install -y ros-humble-rclcpp ros-humble-rosbag2-cpp ros-humble-rosbag2-storage libyaml-cpp-dev libopencv-dev ros-humble-cv-bridge ros-humble-sensor-msgs ros-humble-pcl-conversions ros-humble-pcl-ros libpcl-dev ros-humble-ament-index-cpp ros-humble-nav-msgs 
+sudo apt install -y ros-humble-rclcpp ros-humble-rosbag2-cpp ros-humble-rosbag2-storage libyaml-cpp-dev libopencv-dev ros-humble-cv-bridge ros-humble-sensor-msgs ros-humble-pcl-conversions ros-humble-pcl-ros libpcl-dev ros-humble-ament-index-cpp ros-humble-nav-msgs
 ```
 *Note: Replace 'humble' with your ROS 2 distribution if different.*
 
@@ -86,11 +86,11 @@ storage_id: "sqlite3"  # Common storage ID; ensure it matches your bag's storage
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "16UC1"
+    encoding: "8UC1"    # Options: "16UC1" (raw depth), "bgr8"/"rgb8" (color), "mono8"/"8UC1" (grayscale)
     sample_interval: 10  # Write one sample every 10 messages
   - name: "/camera/color/image_raw"
     type: "Image"
-    encoding: "rgb8"
+    encoding: "rgb8"     # Options: "rgb8" (default), "bgr8", "mono8", "mono16"
     sample_interval: 5   # Write one sample every 5 messages
   - name: "/camera/color/image_raw/compressed"
     type: "CompressedImage"
@@ -105,11 +105,11 @@ topics:
     type: "PointCloud2"
     sample_interval: 10   # Write one sample every 10 messages
     save_mode: "auto"    # Optional: "intensity", "rgb", "rgba", or "auto" (default: auto)
-  - name: "/path"                  
-    type: "Path"                   
+  - name: "/path"
+    type: "Path"
     sample_interval: 1    # Write one sample every single message
-  - name: "/odom"                  
-    type: "Odometry"               
+  - name: "/odom"
+    type: "Odometry"
     sample_interval: 1    # Write one sample every single message
 ```
 
@@ -122,6 +122,16 @@ topics:
 - **topics**: A list of topics to export. Each topic requires:
   - **name**: The ROS 2 topic name.
   - **type**: The message type (PointCloud2, Image, DepthImage, IMU, GPS, etc.).
+  - **encoding**: Format-specific encoding:
+    - For Image:
+      - `"rgb8"`: RGB color (default)
+      - `"bgr8"`: BGR color
+      - `"mono8"`: 8-bit grayscale
+      - `"mono16"`: 16-bit grayscale
+    - For DepthImage (supports visualization options):
+      - `"16UC1"`: Raw depth values (default, best for quantitative analysis)
+      - `"bgr8"` or `"rgb8"`: Colored visualization using JET colormap (red=close, blue=far)
+      - `"mono8"` or `"8UC1"`: Grayscale visualization (darker=closer, brighter=farther)
   - **sample_interval**: The interval at which messages will be written (e.g., 100 for every 100 messages).
   - **save_mode** (PointCloud2 only, optional):
     - `"intensity"`: Save PCD with intensity field (if present).
@@ -148,7 +158,7 @@ storage_id: "sqlite3"
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "16UC1"
+    encoding: "8UC1"
     sample_interval: 10
   - name: "/camera/color/image_raw"
     type: "Image"
@@ -164,11 +174,11 @@ topics:
     type: "PointCloud2"
     sample_interval: 10
     save_mode: "auto"
-  - name: "/path"                  
-    type: "Path"                   
+  - name: "/path"
+    type: "Path"
     sample_interval: 1
-  - name: "/odom"                  
-    type: "Odometry"               
+  - name: "/odom"
+    type: "Odometry"
     sample_interval: 1
 ```
 
@@ -223,7 +233,7 @@ Contributions are welcome! Please follow the standard process:
 This project is licensed under the Apache License 2.0.
 
 ## Contact
-Maintainer: Abdalrahman M. Amer 
+Maintainer: Abdalrahman M. Amer
 
 Email: abdalrahman.m5959@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ storage_id: "sqlite3"  # Common storage ID; ensure it matches your bag's storage
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "8UC1"    # Options: "16UC1" (raw depth), "bgr8"/"rgb8" (color), "mono8"/"8UC1" (grayscale)
+    encoding: "rgb8"    # Options: "rgb8" (default, color), "bgr8" (color), "mono8"/"8UC1" (grayscale), "16UC1" (raw depth)
     sample_interval: 10  # Write one sample every 10 messages
   - name: "/camera/color/image_raw"
     type: "Image"
@@ -122,16 +122,18 @@ topics:
 - **topics**: A list of topics to export. Each topic requires:
   - **name**: The ROS 2 topic name.
   - **type**: The message type (PointCloud2, Image, DepthImage, IMU, GPS, etc.).
-  - **encoding**: Format-specific encoding:
+  - **encoding** (for Image and DepthImage):
     - For Image:
       - `"rgb8"`: RGB color (default)
       - `"bgr8"`: BGR color
       - `"mono8"`: 8-bit grayscale
       - `"mono16"`: 16-bit grayscale
     - For DepthImage (supports visualization options):
-      - `"16UC1"`: Raw depth values (default, best for quantitative analysis)
-      - `"bgr8"` or `"rgb8"`: Colored visualization using JET colormap (red=close, blue=far)
-      - `"mono8"` or `"8UC1"`: Grayscale visualization (darker=closer, brighter=farther)
+      - `"rgb8"`: Standard depth visualization (close=red, far=blue, matches RealSense and other common tools)
+      - `"bgr8"`: Inverse depth visualization (close=blue, far=red)
+      - `"16UC1"`: Raw depth values (best for quantitative analysis)
+      - `"mono8"` or `"8UC1"`: Grayscale (dark=close, bright=far, standard convention)
+      Note: Invalid/zero depth values appear as black in all visualization modes
   - **sample_interval**: The interval at which messages will be written (e.g., 100 for every 100 messages).
   - **save_mode** (PointCloud2 only, optional):
     - `"intensity"`: Save PCD with intensity field (if present).
@@ -158,7 +160,7 @@ storage_id: "sqlite3"
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "8UC1"
+    encoding: "rgb8"
     sample_interval: 10
   - name: "/camera/color/image_raw"
     type: "Image"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ storage_id: "sqlite3"  # Common storage ID; ensure it matches your bag's storage
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "rgb8"    # Options: "rgb8" (default, color), "bgr8" (color), "mono8"/"8UC1" (grayscale), "16UC1" (raw depth)
+    encoding: "bgr8"    # Options: "bgr8" (default, color), "rgb" (color), "mono8"/"8UC1" (grayscale), "16UC1" (raw depth)
     sample_interval: 10  # Write one sample every 10 messages
   - name: "/camera/color/image_raw"
     type: "Image"
@@ -129,8 +129,8 @@ topics:
       - `"mono8"`: 8-bit grayscale
       - `"mono16"`: 16-bit grayscale
     - For DepthImage (supports visualization options):
-      - `"rgb8"`: Standard depth visualization (close=red, far=blue, matches RealSense and other common tools)
-      - `"bgr8"`: Inverse depth visualization (close=blue, far=red)
+      - `"bgr8"`: Standard depth visualization (close=blue, far=red)
+      - `"rgb8"`: Inverse depth visualization (close=red, far=blue)
       - `"16UC1"`: Raw depth values (best for quantitative analysis)
       - `"mono8"` or `"8UC1"`: Grayscale (dark=close, bright=far, standard convention)
       Note: Invalid/zero depth values appear as black in all visualization modes
@@ -160,7 +160,7 @@ storage_id: "sqlite3"
 topics:
   - name: "/camera/depth/image_raw"
     type: "DepthImage"
-    encoding: "rgb8"
+    encoding: "bgr8"
     sample_interval: 10
   - name: "/camera/color/image_raw"
     type: "Image"

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -33,7 +33,7 @@ topics:
   # Configuration for the depth image topic
   - name: "/depth_image_topic"  # Name of the topic to extract
     type: "DepthImage"          # Data type of the topic
-    encoding: "8UC1"            # Encoding format for the depth image
+    encoding: "bgr8"            # Encoding format for the depth image
     sample_interval: 2          # Write one sample every 2 messages
 
   # Configuration for the laser scan topic

--- a/config/exporter_config.yaml
+++ b/config/exporter_config.yaml
@@ -33,7 +33,7 @@ topics:
   # Configuration for the depth image topic
   - name: "/depth_image_topic"  # Name of the topic to extract
     type: "DepthImage"          # Data type of the topic
-    encoding: "16UC1"           # Encoding format for the depth image
+    encoding: "8UC1"            # Encoding format for the depth image
     sample_interval: 2          # Write one sample every 2 messages
 
   # Configuration for the laser scan topic

--- a/include/rosbag2_exporter/handlers/depth_image_handler.hpp
+++ b/include/rosbag2_exporter/handlers/depth_image_handler.hpp
@@ -35,6 +35,52 @@ public:
     }
   }
 
+  // Helper function to check if encoding is color (bgr8/rgb8)
+  bool isColorEncoding(const std::string & enc) {
+    return (enc == "bgr8" || enc == "rgb8");
+  }
+
+  // Helper function to check if encoding is grayscale (mono8/8UC1)
+  bool isGrayscaleEncoding(const std::string & enc) {
+    return (enc == "mono8" || enc == "8UC1");
+  }
+
+  // Convert depth image to visualization format
+  cv::Mat convertDepthToVisualization(const cv::Mat& depth_img) {
+    cv::Mat visualization;
+    double min_val, max_val;
+    cv::minMaxLoc(depth_img, &min_val, &max_val);
+
+    // Skip zero values in min/max computation for better normalization
+    cv::Mat mask = depth_img > 0;
+    if (cv::countNonZero(mask) > 0) {
+      cv::minMaxLoc(depth_img, &min_val, &max_val, nullptr, nullptr, mask);
+    }
+
+    // Normalize to 0-255 range, keeping zero values as zero
+    cv::Mat normalized;
+    depth_img.convertTo(normalized, CV_8UC1, 255.0 / (max_val - min_val), -min_val * 255.0 / (max_val - min_val));
+
+    if (isColorEncoding(encoding_)) {
+      // Apply colormap for color visualization
+      cv::applyColorMap(normalized, visualization, cv::COLORMAP_JET);
+
+      // Keep zero values as black
+      if (cv::countNonZero(mask) < depth_img.total()) {
+        visualization.setTo(cv::Vec3b(0,0,0), ~mask);
+      }
+
+      // Convert to RGB if needed
+      if (encoding_ == "rgb8") {
+        cv::cvtColor(visualization, visualization, cv::COLOR_BGR2RGB);
+      }
+    } else if (isGrayscaleEncoding(encoding_)) {
+      visualization = normalized;
+    }
+
+    return visualization;
+  }
+
   void process_message(const rclcpp::SerializedMessage & serialized_msg,
                       const std::string & topic,
                       size_t index) override
@@ -47,18 +93,11 @@ public:
     // Convert the sensor message to a cv::Mat image using cv_bridge
     cv_bridge::CvImagePtr cv_ptr;
     try {
-      cv_ptr = cv_bridge::toCvCopy(img, encoding_);
+      // Always read as 16UC1 first to get raw depth data
+      cv_ptr = cv_bridge::toCvCopy(img, "16UC1");
     } catch (const cv_bridge::Exception & e) {
-      RCLCPP_ERROR(logger_, "CV Bridge exception: %s. Using default encoding '16UC1'.", e.what());
-
-      // Attempt to fallback to the default '16UC1' encoding
-      try {
-        cv_ptr = cv_bridge::toCvCopy(img, "16UC1");
-        encoding_ = "16UC1";  // Update to fallback encoding
-      } catch (const cv_bridge::Exception & e2) {
-        RCLCPP_ERROR(logger_, "Fallback to '16UC1' failed: %s", e2.what());
-        return;
-      }
+      RCLCPP_ERROR(logger_, "CV Bridge exception: %s", e.what());
+      return;
     }
 
     // Create a timestamped filename
@@ -67,9 +106,6 @@ public:
                 << std::setw(9) << std::setfill('0') << img.header.stamp.nanosec;
     std::string timestamp = ss_timestamp.str();
 
-    // Create the full file path with '.png' as the extension
-    std::string filepath = topic_dir_ + "/" + timestamp + ".png";
-
     // Ensure the directory exists, create if necessary
     std::filesystem::path dir_path = topic_dir_;
     if (!std::filesystem::exists(dir_path)) {
@@ -77,19 +113,25 @@ public:
       std::filesystem::create_directories(dir_path);
     }
 
-    // Normalize depth image for better visualization if needed
-    cv::Mat depth_image;
-    if (encoding_ == "16UC1") {
-      cv_ptr->image.convertTo(depth_image, CV_16UC1);  // No normalization applied here
+    // Process and save the image based on encoding
+    cv::Mat output_image;
+    if (isColorEncoding(encoding_) || isGrayscaleEncoding(encoding_)) {
+      output_image = convertDepthToVisualization(cv_ptr->image);
     } else {
-      depth_image = cv_ptr->image;  // Handle other encodings
+      // For raw depth, keep original
+      output_image = cv_ptr->image;
     }
 
-    // Write the depth image to disk
-    if (!cv::imwrite(filepath, depth_image)) {
-      RCLCPP_ERROR(logger_, "Failed to write depth image to %s", filepath.c_str());
+    // Create the full file path
+    std::string filepath = topic_dir_ + "/" + timestamp + ".png";
+
+    // Save the image
+    if (cv::imwrite(filepath, output_image)) {
+      RCLCPP_INFO(logger_, "Processing depth image #%zu: SAVED to %s",
+                  index, filepath.c_str());
     } else {
-      RCLCPP_INFO(logger_, "Successfully wrote depth image to %s", filepath.c_str());
+      RCLCPP_ERROR(logger_, "Processing depth image #%zu: FAILED to save to %s",
+                   index, filepath.c_str());
     }
   }
 


### PR DESCRIPTION
This PR adds improved depth image visualization options to the `DepthImageHandler` class, providing more flexible and intuitive ways to view depth data. The default `"16UC1"` was hard to visualise. In addition, 2 options are provided below. With Color bgr8 (close=blue, far=red) set as the default.

- **Color Visualization**
  - Encodings: `"bgr8"` or `"rgb8"`
  - Uses JET colormap for intuitive depth representation
  - Color mapping (for bgr8, rgb8 is of the inverse):
    - Red: Far objects
    - Green: Mid-range objects
    - Blue: Near objects
    - Black: Invalid/zero depth values

- **Grayscale Visualization**
  - Encodings: `"mono8"` or `"8UC1"` (same effect)
  - Normalized to 0-255 range
  - Darker pixels represent closer objects
  - Brighter pixels represent farther objects
  - Zero depth values preserved as black

![image](https://github.com/user-attachments/assets/2dade675-11a4-4916-8e42-36969d5f1531)

Functionality tested, documentation and readme updated. The image on the right in the screenshot above is using bgr8 color.